### PR TITLE
bump ol-pmtiles to 1.0.0

### DIFF
--- a/map/package-lock.json
+++ b/map/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "ol": "^10.0.0",
         "ol-ext": "^4.0.22",
-        "ol-pmtiles": "^0.5.0"
+        "ol-pmtiles": "^1.0.0"
       },
       "devDependencies": {
         "vite": "^5.4.0"
@@ -733,11 +733,12 @@
       }
     },
     "node_modules/ol-pmtiles": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ol-pmtiles/-/ol-pmtiles-0.5.0.tgz",
-      "integrity": "sha512-+S/Hk8tjHQluZLC89Ynj8v9twLrlI9NUUvrwp1BLCTLsvqPTfIT6oiFcT3R1/FTEDEOdtpFVLrqarYqA7XFq8w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ol-pmtiles/-/ol-pmtiles-1.0.0.tgz",
+      "integrity": "sha512-wv7YHfSOG3fdnVBdcrIM8OmEbJTUhEaVgVDwiO13Y+MiyKha8nshNXeHqZ7mUTWi5b2ZUJO1k43J2m818Z/jmA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "pmtiles": "^3.0.4"
+        "pmtiles": "^3.0.7"
       },
       "peerDependencies": {
         "ol": ">=9.0.0"

--- a/map/package.json
+++ b/map/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "ol": "^10.0.0",
     "ol-ext": "^4.0.22",
-    "ol-pmtiles": "^0.5.0"
+    "ol-pmtiles": "^1.0.0"
   }
 }


### PR DESCRIPTION
Not sure if related to https://github.com/protomaps/PMTiles/issues/445 but `ol-pmtiles` 1.0 is out now with proper module and TypeScript support and fixes a couple of hairy potential-bugs.